### PR TITLE
Makefile for running app on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 
 COPY target/peakQuiz-backend-0.0.1-SNAPSHOT.jar /app/peakQuiz-backend.jar
 
-# To run:
-    # - docker build -t peakquiz-backend .
-    # -  docker run -d -p 8080:8080 peakquiz-backend
+EXPOSE 8080
+
 CMD ["java", "-jar", "peakQuiz-backend.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+run:
+	docker run --rm --name peakquizApp -p 7878:8080 peakquiz-backend
+
+build:
+	mvn clean package
+	docker build -t peakquiz-backend .


### PR DESCRIPTION
La til en makefile for å lettere kjøre backend i docker.

EXPOSE 8080 er bare for dokumentasjon og gjør ingenting i praksis

Kan nå runne backend på docker med "make run". Man må først bygge jar-filen som kjører på docker med "make build"